### PR TITLE
add test for downloading dependency without time, added conditional t…

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -53,7 +53,7 @@ async function updateMetadata(versionMetadata, defaultMetadata, registryUrl, loc
   const localMetadataPath = metadataPath(name, localFolder)
   const localMetadata = await loadMetadata(localMetadataPath, defaultMetadata)
   localMetadata.versions[version] = versionMetadata
-  localMetadata.time[version] = defaultMetadata.time[version]
+  localMetadata.time[version] = (defaultMetadata.time) ? defaultMetadata.time[version] : "";
   localMetadata['dist-tags'].latest = Object.keys(localMetadata.versions).sort(semver.compare).pop()
   await saveMetadata(localMetadataPath, localMetadata)
 }

--- a/test/download-test.js
+++ b/test/download-test.js
@@ -13,7 +13,8 @@ describe('download', () => {
       const packages = [
         {id: "abbrev@1.1.0", name: "abbrev", version: "1.1.0"},
         {id: "abbrev@1.1.1", name: "abbrev", version: "1.1.1"},
-        {id: "aproba@1.2.0",name: "aproba", version: "1.2.0"}
+        {id: "aproba@1.2.0",name: "aproba", version: "1.2.0"},
+        {id: "@csstools/normalize.css@9.0.1", name: "@csstools/normalize.css", version: "9.0.1"}
       ]
       await downloadAll(packages, options)
   })


### PR DESCRIPTION
Bumped to a dependency without the time value, registry-sync failed because of the missing 'time' property. The default value could probably be something better? 